### PR TITLE
[Monorepo] fix #8 external/full monorepo path issue

### DIFF
--- a/.monorepo
+++ b/.monorepo
@@ -1,5 +1,4 @@
 base_url: https://github.com/biurad/poakium.git
-base_path: ['packages', 'tools']
 
 # All branches that match this regular expression will be split by default
 branch_filter: /^(master|issue-[\d+]|\d+\.\d+)$/
@@ -12,14 +11,15 @@ workers:
   merge:
     - Biurad\Monorepo\Worker\MergeRepoWorker
 
-
 # List of all split projects
 repositories:
   git-scm:
     url: https://github.com/biurad/php-git-scm.git
+    path: tools/git-scm
 
   monorepo:
     url: https://github.com/biurad/php-monorepo.git
+    path: tools/monorepo
 
 # An array of configuration's which custom workers may rely on
 #extra: ~

--- a/tools/monorepo/README.md
+++ b/tools/monorepo/README.md
@@ -17,7 +17,7 @@ A PHP library for working with Monorepo Project's. This library handles splittin
 
 ## 📦 Installation
 
-PHP 8.0 or newer and [GIT][1] 2.25 or newer are required. The recommended way to install, is by using [Composer][2]. Simply run:
+PHP 8.0 or newer and [GIT][1] 2.30 or newer are required. The recommended way to install, is by using [Composer][2]. Simply run:
 
 ```bash
 $ composer require biurad/monorepo

--- a/tools/monorepo/README.md
+++ b/tools/monorepo/README.md
@@ -36,9 +36,6 @@ Here is an example of the *.monorepo* config:
 # URL or absolute path to the remote GIT repository of the monorepo
 base_url: https://github.com/YOUR-VENDORNAME/YOUR-PROJECT.git
 
-# Base directories where sub repo paths can be found
-base_path: ['packages', 'plugins']
-
 # All branches that match this regular expression will be split by default
 branch_filter: /^(main|develop|\d+\.\d+)$/
 
@@ -63,7 +60,7 @@ repositories:
   second-subfolder:
     # URL or absolute path to the remote GIT repository
     url: https://github.com/YOUR-VENDORNAME/YOUR-SECOND-SPLIT-PROJECT.git
-    # A path which exist in `base_path` or an absolute path to sub repo
+    # A path which exist in the root path where monorepo command is called
     # If not defined, this config key (second-subfolder) is used as path
     path: php-example
     # If true, Repo supports merging & splitting. If false, only splitting is supported

--- a/tools/monorepo/src/Worker/SplitCommitsWorker.php
+++ b/tools/monorepo/src/Worker/SplitCommitsWorker.php
@@ -16,6 +16,7 @@ use Biurad\Git\Repository;
 use Biurad\Monorepo\{Monorepo, WorkerInterface, WorkflowCommand};
 use Symfony\Component\Console\Input\{InputInterface, InputOption};
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Process\{ExecutableFinder, Process};
 
 /**
@@ -95,6 +96,10 @@ class SplitCommitsWorker implements WorkerInterface
             $output,
             static function (array $required) use ($input, $output, $currentBranch, $branches, $split, $repo, $mainRepo): int {
                 [$url, $remote, $path, $clonePath] = $required;
+
+                if (!\file_exists($mainRepo->getPath()."/$path")) {
+                    throw new InvalidOptionsException(\sprintf('The repo for "%s" path "%s" does not exist.', $remote, $path));
+                }
 
                 foreach (\array_unique($branches) as $branch) {
                     $output->writeln(\sprintf('<info>Splitting commits from branch %s into %s</info>', $branch, $url));

--- a/tools/monorepo/src/WorkflowCommand.php
+++ b/tools/monorepo/src/WorkflowCommand.php
@@ -96,7 +96,7 @@ class WorkflowCommand extends Command
     {
         $repositories = [];
         $this->output = new SymfonyStyle($input, $output);
-        $config = new Config($input->getOption('path') ?? $this->rootPath, $input->getOption('cache'));
+        $config = new Config(\rtrim($input->getOption('path') ?? $this->rootPath, '\/'), $input->getOption('cache'));
         $exclusive = $input->getOption('only');
 
         if (empty($jobWorkers = $config['workers'][$stage = $input->getArgument('job')] ?? [])) {


### PR DESCRIPTION
## Discussion
Prevent use of full or external path in splitting commits

## Motivation and context
This is very dangerous to commits history and should not be supported in the first place

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Deprecation (un-wanted or renamed functionality that should be removed)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](./../CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
