### PR TITLE
[Monorepo] fix #15 Request for --clean options for monorepo commands

### DIFF
--- a/tools/git-scm/src/Repository.php
+++ b/tools/git-scm/src/Repository.php
@@ -614,11 +614,7 @@ class Repository
             return false;
         }
 
-        if (\is_string($expected)) {
-            return $expected === ($o ?? null);
-        }
-
-        return null === $expected ? true : $expected($o ?? null);
+        return isset($o) ? ($expected === $o || (\is_callable($expected) ? $expected($o) : true)) : false;
     }
 
     /**

--- a/tools/monorepo/src/Config.php
+++ b/tools/monorepo/src/Config.php
@@ -26,13 +26,14 @@ final class Config implements \ArrayAccess, \Countable
     /** @var array<string,mixed> */
     private array $config;
 
-    public function __construct(string $rootPath, string $cachePath = null)
+    public function __construct(string $rootPath, string $cachePath = null, bool $reclone)
     {
         if (!\file_exists($configFile = ($this->config['path'] = $rootPath).'/.monorepo')) {
             throw new \RuntimeException(\sprintf('Config file "%s" does not exist.', $configFile));
         }
 
         $workers = [];
+        $this->config['reclone'] = $reclone;
         $options = new OptionsResolver();
         $options
             ->define('base_url')->default(null)->allowedTypes('string', 'null')

--- a/tools/monorepo/src/Monorepo.php
+++ b/tools/monorepo/src/Monorepo.php
@@ -61,12 +61,16 @@ class Monorepo
             }
 
             if (\file_exists($clonePath = \rtrim($this->config['cache'], '\/').'/'.$remote)) {
-                $output->writeln(\sprintf('Deleting previous clone of <info>%s</info>', $remote));
-                Process::fromShellCommandline(('\\' === \DIRECTORY_SEPARATOR ? 'rd /s /q "' : 'rm -rf "').$clonePath.'"')->run();
+                if ($this->config['reclone']) {
+                    $output->writeln(\sprintf('Deleting previous clone of <info>%s</info>', $remote));
+                    Process::fromShellCommandline(('\\' === \DIRECTORY_SEPARATOR ? 'rd /s /q "' : 'rm -rf "').$clonePath.'"')->run();
+                } else {
+                    $this->repository->run('pull', ['--all'], cwd: $clonePath);
+                }
             }
 
             $output->writeln(\sprintf('<info>Cloning %s into %s</info>', $url, $clonePath));
-            \mkdir($clonePath, recursive: true);
+            @\mkdir($clonePath, recursive: true);
             $this->repository->run('clone', ['-q', '--bare', $url, $clonePath]);
 
             if (0 !== $this->repository->getExitCode()) {

--- a/tools/monorepo/src/WorkflowCommand.php
+++ b/tools/monorepo/src/WorkflowCommand.php
@@ -86,6 +86,7 @@ class WorkflowCommand extends Command
         $this->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not perform operations, just their preview');
         $this->addOption('path', 'p', InputOption::VALUE_OPTIONAL, 'Absolute path to project\'s directory, defaults to directory were script is called.');
         $this->addOption('cache', 'c', InputOption::VALUE_OPTIONAL, 'Absolute path to cache directory, defaults to .monorepo-cache in the project directory.');
+        $this->addOption('clean', 'x', InputOption::VALUE_NONE, 'Re-clone cached repositories of monorepo\'s sub-repo');
         $this->addOption('only', 'o', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'List of sub-repos specified by repo name', []);
     }
 
@@ -96,7 +97,7 @@ class WorkflowCommand extends Command
     {
         $repositories = [];
         $this->output = new SymfonyStyle($input, $output);
-        $config = new Config(\rtrim($input->getOption('path') ?? $this->rootPath, '\/'), $input->getOption('cache'));
+        $config = new Config(\rtrim($input->getOption('path') ?? $this->rootPath, '\/'), $input->getOption('cache'), $input->getOption('clean'));
         $exclusive = $input->getOption('only');
 
         if (empty($jobWorkers = $config['workers'][$stage = $input->getArgument('job')] ?? [])) {


### PR DESCRIPTION
## Discussion
Every time the monorepo's split command is called, repositories re-clone. For instance, if my project contains 100 sub-repo, re-cloning every time is huge.

Currently, there's no workaround and including a `--clean` options to monorepo's workflow commands is necessary if the developer decides to choose a re-clone. More so, the `--only` option already provided is helpful as it allows re-clone support for a single or list of repositories.

## Motivation and context

Making monorepo's workflow commands work faster and reduce cost of bandwidth for better developer experience.
This PR closes #15

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Deprecation (un-wanted or renamed functionality that should be removed)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTING.md](./../CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
